### PR TITLE
allow toFrame() out of buffer and configurable pagesize

### DIFF
--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -364,7 +364,7 @@
                         plugin.frames[i] = img;
                         //buffer.splice(buffer.indexOf(img), 1);
                         drawProgress();
-                        if (beginPlaying && i == (index + pageSize - 1) && direction == 'forward' && playing == false) {
+                        if (beginPlaying && i == (index + plugin.settings.pageSize - 1) && direction == 'forward' && playing == false) {
                             plugin.play();
                         }
                     }).prop('src', $img.data('src'));

--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -19,21 +19,11 @@
         var index = 0;
         var buffer = [];
         var playTimer = null;
-        var frameWidth;
-        var frameHeight;
 
         plugin.settings = {};
 
         plugin.getTotalFrames = function() {
             return total;
-        };
-
-        plugin.getFrameWidth = function() {
-            return frameWidth;
-        };
-
-        plugin.getFrameHeight = function() {
-            return frameHeight;
         };
 
         plugin.controls = {
@@ -323,8 +313,6 @@
                             vw = cw;
                             vh = ih * (cw/iw);
                         }
-                        frameWidth = vw;
-                        frameHeight = vh;
                         screen.clearRect(0, 0, cw, ch);
                         screen.drawImage(img, (cw - vw) / 2, (ch - vh) / 2, vw, vh);
                     }

--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -317,8 +317,9 @@
                         screen.drawImage(img, (cw - vw) / 2, (ch - vh) / 2, vw, vh);
                     }
                 } else if (buffer.length) {
+                    var wasPlaying = playing;
                     plugin.pause();
-                    loadMore();
+                    loadMore(index, wasPlaying);
                     return;
                 }
 
@@ -344,16 +345,16 @@
             }
         };
 
-        var loadMore = function(fromIdx) {
+        var loadMore = function(fromIdx, beginPlaying) {
             var loadFrom = fromIdx != undefined ? fromIdx : index;
             if (buffer.length) {
                 for(var i = loadFrom; (i < plugin.settings.pageSize + loadFrom && i < buffer.length); i++) {
-                    loadFrame(i);
+                    loadFrame(i, beginPlaying);
                 }
             }
         };
 
-        var loadFrame = function(i) {
+        var loadFrame = function(i, beginPlaying) {
             if (i < buffer.length) {
                 var img = buffer[i];
                 var $img = $(img);
@@ -363,6 +364,9 @@
                         plugin.frames[i] = img;
                         //buffer.splice(buffer.indexOf(img), 1);
                         drawProgress();
+                        if (beginPlaying && i == (index + pageSize - 1) && direction == 'forward' && playing == false) {
+                            plugin.play();
+                        }
                     }).prop('src', $img.data('src'));
                 }
             }

--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -341,7 +341,7 @@
         };
 
         var loadMore = function(fromIdx) {
-            if (fromIdx) {
+            if (fromIdx != undefined) {
                 buffer = [];
                 // we have jumpped forward, get a fresh buffer
                 for(var i = fromIdx; (i < plugin.settings.pageSize + fromIdx); i++) {

--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -303,7 +303,7 @@
                 var $img = $(img);
 
                 if (img) {
-                    if($img.prop('naturalHeight') > 0) {
+                    if ($img.prop('naturalHeight') > 0) {
                         var cw = $canvas.width();
                         var ch = $canvas.height();
                         var iw = img.width;
@@ -407,6 +407,11 @@
         var resize = function() {
             $canvas.prop({height: $el.height(), width: $el.width()});
         };
+
+        plugin.fitCanvas = function() {
+            resize();
+        };
+
 
         plugin.init();
     };

--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -3,7 +3,8 @@
         var defaults = {
             name: 'imgplay',
             rate: 1,
-            controls: true
+            controls: true,
+            pageSize: 5
         };
 
         var plugin = this;
@@ -14,7 +15,6 @@
         var playing = false;
         var direction = 'forward';
         var page = 1;
-        var pageSize = 5;
         var total = 0;
         var index = 0;
         var buffer = [];
@@ -188,7 +188,12 @@
         plugin.toFrame = function(i) {
             i = i < 0 ? 0 : i;
 
-            if(i < buffer.length) {
+            if (i < buffer.length) {
+                index = i;
+                drawFrame();
+            }
+            else {
+                loadMore(i);
                 index = i;
                 drawFrame();
             }
@@ -321,7 +326,7 @@
                 if(playing) {
                     if(direction == 'forward') {
                         index++;
-                        if(index > plugin.frames.length -  pageSize / 2) {
+                        if(index > plugin.frames.length -  plugin.settings.pageSize / 2) {
                             loadMore();
                         }
                     } else {
@@ -335,9 +340,16 @@
             }
         };
 
-        var loadMore = function() {
-            if(buffer.length) {
-                for(var i = index; (i < pageSize + index && i < buffer.length); i++) {
+        var loadMore = function(fromIdx) {
+            if (fromIdx) {
+                buffer = [];
+                // we have jumpped forward, get a fresh buffer
+                for(var i = fromIdx; (i < plugin.settings.pageSize + fromIdx); i++) {
+                    loadFrame(i);
+                }
+            }
+            if (buffer.length) {
+                for(var i = index; (i < plugin.settings.pageSize + index && i < buffer.length); i++) {
                     loadFrame(i);
                 }
             }
@@ -353,7 +365,7 @@
                         plugin.frames[i] = img;
                         //buffer.splice(buffer.indexOf(img), 1);
                         drawProgress();
-                        if(i == (index + pageSize - 1) && direction == 'forward' && playing == false) {
+                        if(i == (index + plugin.settings.pageSize - 1) && direction == 'forward' && playing == false) {
                             plugin.play();
                         }
                     }).prop('src', $img.data('src'));


### PR DESCRIPTION
This lets someone configure the pageSize for buffering, leaving the default to 5.

Also if `toFrame()` is called with a frame out of buffer it will fetch a new buffer and jump to that location.