### PR TITLE
when playing we shouldn't load if we are past the total frames

### DIFF
--- a/src/jquery.imgplay.js
+++ b/src/jquery.imgplay.js
@@ -343,7 +343,7 @@
                         screen.clearRect(0, 0, cw, ch);
                         screen.drawImage(img, (cw - vw) / 2, (ch - vh) / 2, vw, vh);
                     }
-                } else if (buffer.length) {
+                } else if (buffer.length && index < total) {
                     var wasPlaying = playing;
                     plugin.pause();
 


### PR DESCRIPTION
this was causing an issue for us as we show a loading indicator which would show at the end as it tries to load more